### PR TITLE
small change, allow '$adler32_checksum' in copy command templates

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -249,7 +249,8 @@ class MoverTask(Task, Logged):
                 .replace("$src_url", data_src_url)  \
                 .replace("$dst_data_path", dest_data_path)   \
                 .replace("$src_data_path", src_data_path)   \
-                .replace("$dst_rel_path", dest_rel_path)
+                .replace("$dst_rel_path", dest_rel_path) \
+                .replace("$adler32_checksum", adler32_checksum)
             #self.debug("copy command:", copy_cmd)
 
             self.timestamp("transferring data")


### PR DESCRIPTION
…for use with gfal-copy --checksum /  xrdcp --cksum

It turns out to be a one-liner, as the value is already lying around 
at the right place in the code.

Tested on fermicloud848, making the config entry:
<pre>
copy_command_template:  "xrdcp --cksum adler32:$adler32_checksum $src_url $dst_url"
</pre>
led to copy commands like:
<pre>
02/28/2024 11:06:31.064: MoverTask[etc_txt_mu2eraw_declad_test_c20240219_17091399855.txt]: [DEBUG] runCommand: xrdcp --cksum adler32:f555152f file:////home/mu2eraw/dropbox/etc_txt_mu2eraw_declad_test_c20240219_17091399855.txt root://fndcadoor.fnal.gov:1094//pnfs/fnal.gov/usr/mu2e/scratch/declad-test-raw/etc/mu2eraw/declad_test/c20240226/txt/1d/08
</pre> 
which check that checksum (which came from the metadata) is what we get on DCache. 