### PR TITLE
field fixes for declad 2.0.3 based on testing at CERN

### DIFF
--- a/declad/custom/dune.py
+++ b/declad/custom/dune.py
@@ -1,4 +1,9 @@
 
+import custom.metadata_converter 
+import os
+import sys
+
+
 mc = metadata_converter.MetadataConverter("dune")
 
 def new_metacat_metadata(desc, metadata, config):
@@ -97,15 +102,15 @@ def sam_metadata(desc, metadata, config):
     if ("metadata" in metadata):
         # is new style metadata..
         out = mc.convert_all_mc_sam(metadata)
+        return out
     else:
         out = metadata.copy()
     out = metadata.copy()
     out["file_name"] = desc.Name
     out["user"] = config.get("samweb", {}).get("user", os.getlogin())
     ck = out.get("checksum")
-
     # take either "checksum" : [ "adler32:xxx" ] or "checksum": "adler32:xxx" 
-    if isisntance(ck, list):
+    if isinstance(ck, list):
         ck = list[0]
 
     if ck:
@@ -123,11 +128,13 @@ def sam_metadata(desc, metadata, config):
         out.pop("metadata")
         out.pop("checksums")
     out.pop("events", None)
-    #print("sam_metadata:"), pprint.pprint(out)
     return out
 
 def get_file_scope(desc, metadata, config):
-    return metadata["runs"][0][2]
+    if isinstance(metadata.get("runs",[None])[0],list):
+        return metadata["runs"][0][2]
+    else:
+        return metadata["metadata"]["core.run_type"]
 
 def get_dataset_scope(desc, metadata, config):
     return get_file_scope(desc, metadata, config)

--- a/declad/custom/metadata_converter.py
+++ b/declad/custom/metadata_converter.py
@@ -35,7 +35,7 @@ g_experiment = None
 # constants for run/subrun combination
 run_scale_factors = { 
     "mu2e": 1000000, 
-    "dune": 1000000, 
+    "dune": 100000, 
     "hypot": 1000,
 }
 
@@ -50,12 +50,15 @@ def convert_runs_sam_mc(runs):
 
 def convert_runs_mc_sam( runs, md):
     """ special case: run/subrun  number conversion"""
-    typ = md["metadata"].get("core.type", md["metadata"].get("md.type", "mc"))
+    typ = md["metadata"].get("core.run_type", md["metadata"].get("md.type", "mc"))
     res = []
     m = run_scale_factors[g_experiment]
+    mysubruns = md["metadata"].get("core.runs_subruns",[])
+    srcount=0
     for r in runs:
-        rn = r // m
-        sr = r % m
+        rn = r
+        sr = mysubruns[srcount] % m
+        srcount += 1
         res.append( [rn, sr, typ] )
     return res
 
@@ -211,8 +214,8 @@ class MetadataConverter:
                 "metadata:core.file_format":        "file_format",
                 "metadata:core.content_status":     "content_status",
                 "metadata:core.event_count":        "event_count",
-                "metadata:core.first_event_number": "first_event_number",
-                "metadata:core.last_event_number":  "last_event_number",
+                "metadata:core.first_event_number": "first_event",
+                "metadata:core.last_event_number":  "last_event",
                 "metadata:core.run_type":           "run_type",
                 "metadata:core.runs":               "runs",
                 "metadata:core.application:family": "family",
@@ -383,6 +386,7 @@ class MetadataConverter:
             ck = self.conversion_mc_sam[self.experiment]["metadata:"+k]
             if ck == "runs":
                 converter = convert_runs_mc_sam
-            res[ck] = converter(v, md)
+            if not ck == "run_type":
+                res[ck] = converter(v, md)
         return res
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -77,8 +77,8 @@ class MoverTask(Task, Logged):
         else:
             # if it is metacat style run list, get run number and type
             rl = meta.get("core.runs", meta.get("rs.runs", [0]))
-            meta["run_number"] = rl[0] // 1000000
-            rt = meta.get("core.type", meta.get("dh.type", "mc"))
+            meta["run_number"] = rl[0]
+            rt = meta.get("core.run_type", meta.get("dh.type", "mc"))
             meta["run_type"] = rt
         return self.RucioConfig["dataset_did_template"] % meta
 


### PR DESCRIPTION
Fixed following issues:

incorrect formula for calculating sam run/subrun from metacat run/subrun
incorrect factor for dune run/subrun
Added headers to dune.py to import custom.metadfata_converter

added a "return out" in the dune.py after the mc.convert_all_mc_sam(metadata)

fixed typo isisnstance -> is instance

made return metadata["runs"][0][2] conditional on metadata type ( only for sam) 
fixed the field to fetch for run_type in convert_runs_mc_sam
Made it calculate the subrun from runs_subruns list rather than runs list

fixed conversion first_event_number (mc) to first_event (sam). same for last_event

Did not pass the run_type through to SAM except as part of the runs triplet.




