### PR TITLE
add a note about symlinking experiment.py as __init__.py in import error

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -8,7 +8,10 @@ from xrootd_scanner import XRootDScanner
 from lfn2pfn import lfn2pfn
 from datetime import datetime, timezone
 
-from custom import metacat_metadata, sam_metadata, get_file_scope, get_dataset_scope, metacat_dataset
+try:
+    from custom import metacat_metadata, sam_metadata, get_file_scope, get_dataset_scope, metacat_dataset
+except:
+    raise FileNotFoundError(f"could not import from custom:\n Did you symlink an experiement.py as __init__.py in {os.path.dirname(__file__)}/custom?")
 
 from pythreader import version_info as pythreader_version_info
 #if pythreader_version_info < (2,15,0):

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 try:
     from custom import metacat_metadata, sam_metadata, get_file_scope, get_dataset_scope, metacat_dataset
 except:
-    raise FileNotFoundError(f"could not import from custom:\n Did you symlink an experiement.py as __init__.py in {os.path.dirname(__file__)}/custom?")
+    raise FileNotFoundError(f"could not import from custom:\n Did you symlink an experiment.py as __init__.py in {os.path.dirname(__file__)}/custom?")
 
 from pythreader import version_info as pythreader_version_info
 #if pythreader_version_info < (2,15,0):


### PR DESCRIPTION
In the current versions of declad, we need installers to add an experiment-specific symlink in the
custom directory.   This catches the import error that results if you do not do so, and gives an error
to remind you.