### PR TITLE
Config required metadata

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -150,7 +150,7 @@ class MoverTask(Task, Logged):
         # strip whitespace from around the attribute names
         metadata = {key.strip():value for key, value in metadata.items()}
 
-        for rlst in self.Config.get("required_metadat", self.RequiredMetadata):
+        for rlst in self.Config.get("required_metadata", self.RequiredMetadata):
             found=False
             for rm in rlst:
                 if rm in metadata:

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -150,7 +150,7 @@ class MoverTask(Task, Logged):
         # strip whitespace from around the attribute names
         metadata = {key.strip():value for key, value in metadata.items()}
 
-        for rlst in self.RequiredMetadata:
+        for rlst in self.Config.get("required_metadat", self.RequiredMetadata):
             found=False
             for rm in rlst:
                 if rm in metadata:

--- a/sample_home/declad_config.yaml
+++ b/sample_home/declad_config.yaml
@@ -21,6 +21,15 @@ download_command_template: "cp $src_path $dst_path"   # metadata file download c
 delete_command_template: "rm $path"                   # clean files out of Dropbox, with $server and $path 
 quarantine_location: /home/hypotraw/quarantine        # location for files / metadata that don't match, etc.
 
+#required_metadata:
+# - - checksum
+#   - checksums
+# - - file_size
+#   - size
+# - - runs
+#   - core.runs
+#   - rs.runs
+
 #history_db: history.sqlite                         # file to keep history
 #interval: 30                                       # scan interval
 #timeout: 30                                        # timeout for scans


### PR DESCRIPTION
Allow required_metadata: setting in the config.yaml, as opposed to hardcoding it.  The default is the existing
list so as to be backwards-compatible. 