### PR TITLE
do an extra xroot stat call to confirm transfer size

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -270,7 +270,7 @@ class MoverTask(Task, Logged):
                 .replace("$dst_data_path", dest_data_path)   \
                 .replace("$src_data_path", src_data_path)   \
                 .replace("$dst_rel_path", dest_rel_path) \
-                .replace("$adler32_checksum", adler32_checksum)
+                .replace("$adler32_checksum", adler32_checksum) \
                 .replace("$file_size", file_size )
             #self.debug("copy command:", copy_cmd)
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -271,6 +271,7 @@ class MoverTask(Task, Logged):
                 .replace("$src_data_path", src_data_path)   \
                 .replace("$dst_rel_path", dest_rel_path) \
                 .replace("$adler32_checksum", adler32_checksum)
+                .replace("$file_size", file_size )
             #self.debug("copy command:", copy_cmd)
 
             self.timestamp("transferring data")
@@ -281,6 +282,16 @@ class MoverTask(Task, Logged):
                 return self.failed("Data copy failed: %s" % (output,))
 
             self.log("data transfer complete")
+
+            try:    
+                dest_size = self.get_file_size(self.DestServer, dest_data_path)
+                self.debug("Destination data file size:", dest_size)
+            except Exception as e:
+                return self.failed(f"Can not get file size at the destination: {e}")
+
+             if dest_size != file_size:
+                 return self.failed("Transferred file has wrong size")
+            
         else:
             self.log("data file already exists at the destination and has correct size. Not overwriting")
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -271,7 +271,7 @@ class MoverTask(Task, Logged):
                 .replace("$src_data_path", src_data_path)   \
                 .replace("$dst_rel_path", dest_rel_path) \
                 .replace("$adler32_checksum", adler32_checksum) \
-                .replace("$file_size", file_size )
+                .replace("$file_size", str(file_size) )
             #self.debug("copy command:", copy_cmd)
 
             self.timestamp("transferring data")

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -289,7 +289,7 @@ class MoverTask(Task, Logged):
             except Exception as e:
                 return self.failed(f"Can not get file size at the destination: {e}")
 
-             if dest_size != file_size:
+            if dest_size != file_size:
                  return self.failed("Transferred file has wrong size")
             
         else:


### PR DESCRIPTION
This is a fix for issue #19.

We were already doing an xrootd stat beforehand to see if the file was already there, we're now doing it
again afterwards to double-check our transfer is complete by verifying the size. So if the copy "succeeds" but
the file sizes don't match, we flag it as a failed transfer.

