### PR TITLE
draft of metadata extractor support

### DIFF
--- a/declad/local_scanner.py
+++ b/declad/local_scanner.py
@@ -83,7 +83,7 @@ class LocalScanner(PyThread, Logged):
     def run(self):
         prev_data_files = {}
         extracted = set()
-        old_extracted = set()
+        extracted_old = set()
         extracted_clean_count = 0
         while not self.Stop:
             if self.Receiver.low_water():


### PR DESCRIPTION
Draft of metadata extractor support #17.
If files are dropped off without metadata (we check that we have done 2 directory scans without seeing it) 
and we have a metadata extractor defined, run the metadata extractor on those files. 
Currently we build up a set of files we have already launched the extractor on; this needs pruning...


