### PR TITLE
Token support

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -1,3 +1,8 @@
+try:
+    from custom import metacat_metadata, sam_metadata, get_file_scope, get_dataset_scope, metacat_dataset
+except:
+    raise AttributeError("Unable to import 'custom', did you forget to symlink experiment.py as __init__.py?")
+
 from pythreader import PyThread, synchronized, Primitive, Task, TaskQueue
 from tools import runCommand
 import json, hashlib, traceback, time, os, pprint, textwrap
@@ -8,7 +13,6 @@ from xrootd_scanner import XRootDScanner
 from lfn2pfn import lfn2pfn
 from datetime import datetime, timezone
 
-from custom import metacat_metadata, sam_metadata, get_file_scope, get_dataset_scope, metacat_dataset
 
 from pythreader import version_info as pythreader_version_info
 #if pythreader_version_info < (2,15,0):

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -40,7 +40,7 @@ class SAMWebClient(Logged):
             url = self.URL + "/files/name/" + quote(name) + "/metadata?format=json"
         else:
             url = self.URL + f"/files/id/{id}/metadata?format=json"
-        response = requests.get(url, headers=self.headers)
+        response = requests.get(url, headers=self.headers())
         if response.status_code // 100 == 2:
             return response.json()
         else:
@@ -52,7 +52,7 @@ class SAMWebClient(Logged):
         response = requests.post(
             self.URL + "/files", 
             data=data,
-            headers=self.headers,
+            headers=self.headers(),
 			cert=self.CertTuple
         )
         if response.status_code // 100 == 4:

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -41,7 +41,7 @@ class SAMWebClient(Logged):
         else:
             url = self.URL + f"/files/id/{id}/metadata?format=json"
         response = requests.get(url, headers=self.headers())
-        if response.status_code // 100 == 2:
+        if response.status_code // 100 in (4,5):
             return response.json()
         else:
             return None
@@ -55,7 +55,7 @@ class SAMWebClient(Logged):
             headers=self.headers(),
 			cert=self.CertTuple
         )
-        if response.status_code // 100 == 4:
+        if response.status_code // 100 in (4,5):
             raise SAMDeclarationError("SAM declaration error", response.text)
         response.raise_for_status()
         file_id = response.text.strip()
@@ -89,7 +89,7 @@ class SAMWebClient(Logged):
         )
         #self.debug("response:", str(response))
         #self.debug(f"  text:[{response.text}]")
-        if response.status_code // 100 == 4:
+        if response.status_code // 100 in (4,5):
             raise SAMDeclarationError("SAM error adding file location:", response.text)
         response.raise_for_status()
         

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -20,7 +20,7 @@ class SAMWebClient(Logged):
         self.URL = url
         self.Tokenfile = tokenfile
         if cert and key:
-            self.CertTuple = (self.Cert,  self.Key)
+            self.CertTuple = (cert, key)
         else:
             self.CertTuple = None
 

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -15,18 +15,32 @@ class SAMDeclarationError(Exception):
 
 class SAMWebClient(Logged):
     
-    def __init__(self, url, cert, key):
+    def __init__(self, url, cert=None, key=None, tokenfile=None):
         Logged.__init__(self)
         self.URL = url
-        self.Cert = cert
-        self.Key = key
+        self.Tokenfile = tokenfile
+        if cert and key:
+            self.CertTuple = (self.Cert,  self.Key)
+        else:
+            self.CertTuple = None
+
+    def headers(self, base = None):
+        if base:
+            headers = base
+        else:
+            headers = {"Accept":"application/json"}
+        if self.Tokenfile:
+            with os.open(self.Tokenfile, "r") as tf: 
+                token = tf.read().strip()
+            headers["Authentication"] = "Bearer " + token
+        return headers
 
     def get_file(self, name=None, id=None):
         if name:
             url = self.URL + "/files/name/" + quote(name) + "/metadata?format=json"
         else:
             url = self.URL + f"/files/id/{id}/metadata?format=json"
-        response = requests.get(url, headers={"Accept":"application/json"})
+        response = requests.get(url, headers=self.headers)
         if response.status_code // 100 == 2:
             return response.json()
         else:
@@ -35,9 +49,11 @@ class SAMWebClient(Logged):
     def declare(self, metadata, location=None):
         data = json.dumps(metadata, indent=1, sort_keys=True)
         file_name = metadata["file_name"]
-        response = requests.post(self.URL + "/files", data=data,
-                        headers={"Content-Type":"application/json"},
-			cert=(self.Cert, self.Key)
+        response = requests.post(
+            self.URL + "/files", 
+            data=data,
+            headers=self.headers,
+			cert=self.CertTuple
         )
         if response.status_code // 100 == 4:
             raise SAMDeclarationError("SAM declaration error", response.text)
@@ -68,8 +84,8 @@ class SAMWebClient(Logged):
         #self.debug("  url:", url)
         #self.debug("  headers:", headers)
         #self.debug("  data:", data)
-        response = requests.post(url, data=data, headers=headers,
-            cert=(self.Cert, self.Key)
+        response = requests.post(url, data=data, headers=self.headers(headers),
+            cert=self.CertTuple
         )
         #self.debug("response:", str(response))
         #self.debug(f"  text:[{response.text}]")
@@ -87,7 +103,7 @@ class SAMWebClient(Logged):
                 "Accept" : "application/json",
                 "SAM-Role": "default"
             },
-            cert=(self.Cert, self.Key)
+            cert=self.CertTuple
         )
         txt = response.text
         #self.debug("locate_file: response:", str(response))

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -122,7 +122,7 @@ class SAMWebClient(Logged):
 
 def client(config):
     if "url" in config:
-        return SAMWebClient(config["url"], config.get("cert"), config.get("key"))
+        return SAMWebClient(config["url"], config.get("cert",None), config.get("key",None), config.get("tokenfile",None))
     else:
         return None
 


### PR DESCRIPTION
Internal samweb client did not support token authentication; this fixes that. 
So as  soon as Rucio supports token authentication, we can move the whole declad setup to use (only) tokens.