### PR TITLE
get stats reported for metadata extraction

### DIFF
--- a/declad/declad.py
+++ b/declad/declad.py
@@ -22,7 +22,7 @@ class DeclaD(PyThread, Logged):
         self.MoverManager = Manager(config, self.HistoryDB)
         scanner_type = config["scanner"].get("type")
         if scanner_type == "local":
-            self.Scanner = LocalScanner(self.MoverManager, config)
+            self.Scanner = LocalScanner(self.MoverManager, config, history_db)
         elif scanner_type == "xrootd":
             self.Scanner = Scanner(self.MoverManager, config)
         else:

--- a/declad/graphite_interface.py
+++ b/declad/graphite_interface.py
@@ -103,7 +103,7 @@ class GraphiteInterface:
 
 class GraphiteSender(PyThread, Logged):
 
-    Events = ("done", "quarantined", "failed")
+    Events = ("done", "quarantined", "failed", "extracted")
 
     def __init__(self, config, history_db):
         Logged.__init__(self, "GraphiteSender")

--- a/declad/local_scanner.py
+++ b/declad/local_scanner.py
@@ -15,11 +15,12 @@ class LocalScanner(PyThread, Logged):
     # -rw-r--r-- 1 ivm3 ivm3 1228 Mar 22 16:52 /home/ivm3/token
     DefaultParseRE = r"(?P<type>[a-z-])\S+\s+\d+\s+\S+\s+\S+\s+(?P<size>\d+)\s+\S+\s+\d+\s+\S+\s+(?P<path>\S+)$"
 
-    def __init__(self, receiver, config):
+    def __init__(self, receiver, config, historydb = None):
         PyThread.__init__(self, daemon=True, name="Scanner")
         Logged.__init__(self, f"Scanner")
         self.Receiver = receiver
         scan_config = config["scanner"]
+        self.Historydb = historydb
         self.Interval = scan_config.get("interval", self.DefaultInterval)
         self.Location = scan_config["location"]
         self.MetadataExtractorLog = scan_config.get("metadata_extractor_log","")
@@ -136,6 +137,10 @@ class LocalScanner(PyThread, Logged):
                                 #  its been in 2 passes with no metadata found...
                                 extract_list.append(fn)
                                 extracted.add(fn)
+
+                                # log in history/prometheus... assume extraction takes 1 sec
+                                tstart = time.time()
+                                self.Historydb.add_record(fn, None, tstart, tstart+1.0, "extracted", "")
 
                         #self.log(f"metadata_extractor branch: extract_list {repr(extract_list)}")
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -320,7 +320,8 @@ class MoverTask(Task, Logged):
         if sclient is not None:
             self.timestamp("declaring to SAM")
             existing_sam_meta = sclient.get_file(filename)
-            if existing_sam_meta is not None:
+
+            if existing_sam_meta is not None and not "error" in existing_sam_meta:
                 try:    file_id = str(existing_sam_meta["file_id"])
                 except KeyError:
                     return self.quarantine("Existing SAM metadata does not contain file_id")

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -1,6 +1,4 @@
-from logs import Logged
-import requests, json
-from urllib.parse import quote, urlencode
+from logs import Logged import requests, json from urllib.parse import quote, urlencode
 
 class SAMDeclarationError(Exception):
     def __init__(self, message, body=None):

--- a/declad/samweb_client.py
+++ b/declad/samweb_client.py
@@ -1,4 +1,5 @@
-from logs import Logged import requests, json from urllib.parse import quote, urlencode
+from logs import Logged import requests, json 
+from urllib.parse import quote, urlencode
 
 class SAMDeclarationError(Exception):
     def __init__(self, message, body=None):


### PR DESCRIPTION
Adding metadata-extraction counts to the stats we report with graphite, checking for samweb returning
json blob of {'error': 'file does not exist'} when asked for metadata.