### PR TITLE
Also use template_tags() callout on rucio dataset templates

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -90,6 +90,7 @@ class MoverTask(Task, Logged):
             meta["run_number"] = rl[0]
             rt = meta.get("core.run_type", meta.get("dh.type", "mc"))
             meta["run_type"] = rt
+        meta_dict.update(template_tags(metadata))
         return self.RucioConfig["dataset_did_template"] % meta
 
     def undid(self, did):


### PR DESCRIPTION

One-liner change, also callout to template_tags() when expanding the rucio dataset templates.
Thus you can do things like change datasets every 17 subruns, etc.