### PR TITLE
declare parents to MetaCat if present:

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -465,6 +465,7 @@ class MoverTask(Task, Logged):
                             fid=file_id, namespace=file_scope, name=filename, 
                             metadata=metacat_meta, 
                             dataset_did=dataset_did,
+                            parents=metadata.get("parents", []),
                             size=file_size, checksums={ "adler32":  adler32_checksum }
                         )
                     except Exception as e:


### PR DESCRIPTION
This is just adding a parameter to pass data we should have handy... 
but we should declare parentage if it's in the metadata json file.

This fixes issue #32.