### PR TITLE
allowing different metacat vs rucio dataset names

### DIFF
--- a/declad/custom/dune.py
+++ b/declad/custom/dune.py
@@ -138,6 +138,23 @@ def get_file_scope(desc, metadata, config):
 def get_dataset_scope(desc, metadata, config):
     return get_file_scope(desc, metadata, config)
 
+def rucio_dataset(desc, metadata, config):
+    meta = metadata.copy()
+    if "metadata" in metadata:
+        meta.update(metadata["metadata"])
+    if isinstance(meta.get("runs",[None])[0], list):
+        # if it is sam style run list, get run number and type
+        meta["run_number"] = meta["runs"][0][0]
+        meta["run_type"] = meta["runs"][0][2]
+    else:
+        # if it is metacat style run list, get run number and type
+        rl = meta.get("core.runs", meta.get("rs.runs", [0]))
+        meta["run_number"] = rl[0]
+        rt = meta.get("core.run_type", meta.get("dh.type", "mc"))
+        meta["run_type"] = rt
+    meta.update(template_tags(metadata))
+    return config["rucio"]["dataset_did_template"] % meta
+
 def metacat_dataset(desc, metadata, config):
-    return config["metacat_dataset"]
+    return rucio_dataset(desc, metadata, config)
 

--- a/declad/custom/dune.py
+++ b/declad/custom/dune.py
@@ -153,6 +153,10 @@ def rucio_dataset(desc, metadata, config):
         rt = meta.get("core.run_type", meta.get("dh.type", "mc"))
         meta["run_type"] = rt
     meta.update(template_tags(metadata))
+    # if our metadata specifies a dataset, use that; see:
+    # https://github.com/fermitools/declad/issues/35
+    if meta.get("dune.dataset_name", ""):
+        return meta["dune.dataset_name"]
     return config["rucio"]["dataset_did_template"] % meta
 
 def metacat_dataset(desc, metadata, config):

--- a/declad/custom/metadata_converter.py
+++ b/declad/custom/metadata_converter.py
@@ -57,7 +57,10 @@ def convert_runs_mc_sam( runs, md):
     srcount=0
     for r in runs:
         rn = r
-        sr = mysubruns[srcount] % m
+        if srcount < len(mysubruns):
+            sr = mysubruns[srcount] % m
+        else:
+            sr = srcount
         srcount += 1
         res.append( [rn, sr, typ] )
     return res

--- a/declad/custom/mu2e.py
+++ b/declad/custom/mu2e.py
@@ -41,6 +41,23 @@ def get_file_scope(desc, metadata, config):
 def get_dataset_scope(desc, metadata, config):
     return get_file_scope(desc, metadata, config)
 
+def rucio_dataset(desc, metadata, config):
+    meta = metadata.copy()
+    if "metadata" in metadata:
+        meta.update(metadata["metadata"])
+    if isinstance(meta.get("runs",[None])[0], list):
+        # if it is sam style run list, get run number and type
+        meta["run_number"] = meta["runs"][0][0]
+        meta["run_type"] = meta["runs"][0][2]
+    else:
+        # if it is metacat style run list, get run number and type
+        rl = meta.get("core.runs", meta.get("rs.runs", [0]))
+        meta["run_number"] = rl[0]
+        rt = meta.get("core.run_type", meta.get("dh.type", "mc"))
+        meta["run_type"] = rt
+    meta.update(template_tags(metadata))
+    return config["rucio"]["dataset_did_template"] % meta
+
 def metacat_dataset(desc, metadata, config):
     return config.get("metacat_dataset")
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -385,7 +385,7 @@ class MoverTask(Task, Logged):
         #
         # create dataset if does not exist
         #
-        metacat_dataset_did = custom.metacat_dataset( self.FileDesc, metadata, self.config)
+        metacat_dataset_did = custom.metacat_dataset( self.FileDesc, metadata, self.Config)
         dataset_scope, dataset_name = metacat_dataset_did.split(":")
 
         self.log(f"metacat dataset: {dataset_scope}:{dataset_name} vs {self.last_created_metacat_dataset}")
@@ -398,8 +398,8 @@ class MoverTask(Task, Logged):
                 except metacat_client.AlreadyExistsError:
                     pass
 
-        rucio_dataset_did = custom.rucio_dataset(self.FileDesc, metadata, self.config)
-        dataset_scope, dataset_name = dataset_did.split(":")
+        rucio_dataset_did = custom.rucio_dataset(self.FileDesc, metadata, self.Config)
+        dataset_scope, dataset_name = rucio_dataset_did.split(":")
 
         self.log(f"rucio dataset: {dataset_scope}:{dataset_name} vs {self.last_created_rucio_dataset}")
         if f"{dataset_scope}:{dataset_name}" != self.last_created_rucio_dataset:
@@ -453,7 +453,7 @@ class MoverTask(Task, Logged):
                         }
                     if file_id is not None:
                         file_info["fid"] = str(file_id)
-                    self.debug("about to mclient.declare_files dataset_did %s with file_info: %s" % (dataset_did, repr(file_info)))
+                    self.debug("about to mclient.declare_files dataset_did %s with file_info: %s" % (metacat_dataset_did, repr(file_info)))
                     try:    
                         file_info = mclient.declare_file(
                             fid=file_id, namespace=file_scope, name=filename, 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -299,8 +299,10 @@ class MoverTask(Task, Logged):
         #
         file_id = None
         
-        sclient = samweb_client.client(self.SAMConfig)
         do_declare_to_sam = self.Config.get("declare_to_sam", True)
+        if do_declare_to_sam:
+            sclient = samweb_client.client(self.SAMConfig)
+
         if sclient is not None:
             self.timestamp("declaring to SAM")
             existing_sam_meta = sclient.get_file(filename)
@@ -376,6 +378,7 @@ class MoverTask(Task, Logged):
         do_declare_to_metacat = self.Config.get("declare_to_metacat", True)
         if do_declare_to_metacat:
             mclient = metacat_client.client(self.Config)
+
         do_declare_to_rucio = self.RucioConfig.get("declare_to_rucio", True)
         if do_declare_to_rucio:
             rclient = rucio_client.client(self.RucioConfig)
@@ -461,6 +464,7 @@ class MoverTask(Task, Logged):
                     except Exception as e:
                         return self.failed(f"MetaCat declaration failed: {e}")
                     self.log("file declared to MetaCat")
+
             else:
                 self.debug("would declare to MetaCat")
                 self.debug("Name, namespace, fid:", filename, file_scope, file_id)
@@ -482,12 +486,6 @@ class MoverTask(Task, Logged):
                 self.log(f"File replica declared in drop rse {drop_rse}")
 
                 # add the file to the dataset
-                if mclient is not None:
-                    try:
-                        mclient.add_files(f"{dataset_scope}:{dataset_name}",[{"namespace":file_scope, "name": filename}])
-                    except metacat_client.AlreadyExistsError:
-                        self.log("File was already attached to the MetaCat dataset")
-                        pass
                 try:
                     rclient.attach_dids(dataset_scope, dataset_name, [{"scope":file_scope, "name":filename}])
                 except FileAlreadyExists:

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -385,7 +385,7 @@ class MoverTask(Task, Logged):
         #
         # create dataset if does not exist
         #
-        metacat_dataset_did = custom.metadata_dataset( self.FileDesc, metadata, self.config)
+        metacat_dataset_did = custom.metacat_dataset( self.FileDesc, metadata, self.config)
         dataset_scope, dataset_name = metacat_dataset_did.split(":")
 
         self.log(f"metacat dataset: {dataset_scope}:{dataset_name} vs {self.last_created_metacat_dataset}")


### PR DESCRIPTION
Trying to  fix issue #31 ; allowing metacat dataset and rucio dataset to be different, via "custom" per-experiment module; but also allowing them to be the same by having metacat_dataset() call rucio_dataset(). Moved the current code that implements the rucio dataset template into the custom code.