### PR TITLE
File only  hashes

### DIFF
--- a/declad/custom/mu2e.py
+++ b/declad/custom/mu2e.py
@@ -2,6 +2,7 @@
 import custom.metadata_converter 
 import os
 import sys
+import hashlib
 
 mc = metadata_converter.MetadataConverter("mu2e")
 
@@ -46,6 +47,10 @@ def metacat_dataset(desc, metadata, config):
 
 def template_tags(metadata):
     res = {}
+    mhstr = hashlib.md5(metadata['name']).encode('utf-8')).hexdigest()
+    shstr = hashlib.sha256(metadata['name']).encode('utf-8')).hexdigest()
+    res["fo_md5hash"] = "%s/%s" % (mhstr[0:2], mhstr[2:4]),
+    res["fo_sha256hash"] = "%s/%s" % (shstr[0:2], shstr[2:4]),
     if metadata["metadata"]["fn.owner"] == "mu2e":
          res["dirprefix"] =  "phy"
     else:


### PR DESCRIPTION
Adding "fo_md5hash" and "fo_sha256hash" template values based on (only) metadata filename, without scope, 
in the per-experiment custom code, per issue #37 .