### PR TITLE
Custom imports fixes for #41, revisiting #12

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -105,12 +105,11 @@ class MoverTask(Task, Logged):
         return scanner.getFileSize(path)
 
     def run(self):
-        self.log("Log testing...")
         # import a template_tags() routine if present, otherwise nothing local..
         try:
             from custom import template_tags
         except:
-            self.log("No template_tags callout in custom.py; adding default one...")
+            self.log("Notice: no template_tags callout in custom.py; adding default empty one...")
             def template_tags(metadata):
                 return {}
 

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -1,5 +1,6 @@
 try:
     import custom
+    assert(custom.__file__)
 except:
     raise AttributeError("Unable to import 'custom', did you forget to symlink experiment.py as __init__.py?")
 
@@ -14,12 +15,6 @@ from lfn2pfn import lfn2pfn
 from datetime import datetime, timezone
 from rucio.common.exception import DataIdentifierAlreadyExists, DuplicateRule, FileAlreadyExists
 
-# import a template_tags() routine if present, otherwise nothing local..
-try:
-    from custom import template_tags
-except:
-    def template_tags(metadata):
-        return {}
 
 from pythreader import version_info as pythreader_version_info
 #if pythreader_version_info < (2,15,0):
@@ -36,6 +31,7 @@ class MoverTask(Task, Logged):
     def __init__(self, config, filedesc):
         Task.__init__(self, filedesc)
         Logged.__init__(self, name=f"MoverTask[{filedesc.Name}]")
+
         self.FileDesc = filedesc
         self.Config = config
         self.MetaSuffix = config.get("meta_suffix", ".json")
@@ -61,6 +57,7 @@ class MoverTask(Task, Logged):
         self.KeepUntil = None           # keep in memory until this time
         self.DefaultCategory = config.get("default_category")       # default metadata category for unexpeted uncategorized metadata attrs
         self.timestamp("created")
+
 
     def last_event(self, name=None):
         if self.EventLog:
@@ -108,6 +105,15 @@ class MoverTask(Task, Logged):
         return scanner.getFileSize(path)
 
     def run(self):
+        self.log("Log testing...")
+        # import a template_tags() routine if present, otherwise nothing local..
+        try:
+            from custom import template_tags
+        except:
+            self.log("No template_tags callout in custom.py; adding default one...")
+            def template_tags(metadata):
+                return {}
+
         #self.debug("started")
         self.timestamp("started")
         self.Failed = False


### PR DESCRIPTION
Turns out, "import custom" will not throw if there is a "custom" directory in the PYTHONPATH, even if the __init__.py is missing; but you can check that custom.__file__ is set to something and that raises if its there but a directory.

similarly, we check for the import of template_tags in the startup when we run so we can log and stub in a
substitute.  Still not sure why that didn't work at the outer scope, but it seems to work here...