### PR TITLE
Test suite, and https upload support

### DIFF
--- a/declad/config.py
+++ b/declad/config.py
@@ -64,6 +64,7 @@ class Config(dict):
         "source_root_path",
         "source_server",
         "transfer_timeout",
+        "transfer_proto",
         "web_gui.prefix",
         "web_gui.site_title",
         "web_gui.port",

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -509,6 +509,7 @@ class MoverTask(Task, Logged):
 
                 # declare file replica to Rucio
                 drop_rse = self.RucioConfig["drop_rse"]
+                self.log(f"calling add_replica( {drop_rse}, {file_scope}, {filename}, {file_size}, {adler32_checksum})")
                 rclient.add_replica(drop_rse, file_scope, filename, file_size, adler32_checksum)
                 self.log(f"File replica declared in drop rse {drop_rse}")
 

--- a/tests/declad_test.py
+++ b/tests/declad_test.py
@@ -1,0 +1,127 @@
+import os, sys, re, time
+
+class patchit:
+    """ context manager for applying / removing a patch"""
+    def __init__(self, base, patchfile):
+        self.patchfile = patchfile
+        self.base = base
+    def __enter__(self):
+        if self.patchfile:
+            os.system("cd {self.base} && patch -p1 < {patchfile}");
+    def __exit__(self,*args):
+        if self.patchfile:
+            os.system("cd {self.base} && patch -R -p1 < {patchfile}");
+
+# regexps for watch_log...
+re_nfiles  = re.compile(r"scanner returned [1-9] file descriptors")
+re_extract = re.compile(r"Running:.*demo_meta_extractor.sh")
+re_cpcmd   = re.compile(r"runCommand: xrdcp.*[0-9].txt")
+re_after   = re.compile(r"known files before and after: [1-9]")
+re_trace   = re.compile(r"Traceback")
+
+def watch_log(lf, ext_flag):
+    state = 0
+
+    if not os.path.exists(lf):
+        return False
+
+    let_logfile_grow(lf)
+
+    with open(lf, "r") as lfd:
+        for line in lfd.readlines():
+            print(f"saw: {line}")
+            if re_trace.search(line):
+                raise AssertionError("Saw Traceback in log")
+
+            if re_nfiles.search(line) and state == 0:
+                print(f"watch_log => 1: {line}")
+                state = 1
+
+            if  ext_flag and re_extract.search(line) and state == 1:
+                print(f"watch_log => 2: {line}")
+                state = 2
+
+            if re_cpcmd.search(line) and state == (2 if extflag else 1):
+                print(f"watch_log => 3: {line}")
+                state = 3
+
+            if re_after.search(line) and state == 3:
+                print(f"watch_log => done: {line}")
+                # saw everything we expected
+                return True
+
+    print(f"Error: only got to state: {state}")
+    return False
+
+def cleanup_dirs(dlist):
+    for d in dlist:
+        try:
+            os.rmdir(d)
+        except:
+            return False
+
+def run(cmd):
+    print(f"Running: {cmd}")
+    os.system(cmd)
+
+def let_logfile_grow( lf ):
+    """ if logfile is growing, wait up to 3 minutes..."""
+    oldsize = 0
+    time.sleep(2)
+    size  = os.stat(lf)[6]
+    if size > oldsize:
+        time.sleep(330)   # just sleep a little over 5 minutes for now.
+    size  = os.stat(lf)[6]
+    print(f"log size {size}, returning...")
+    return
+
+
+def generic_case( base, custom, patchfile, generator, nfiles, ext_flag, fail):
+
+    res = False
+    # setup custom module link
+    try:
+        os.unlink( f"{base}/custom/__init__.py" )
+    except FileNotFoundError:
+        pass
+
+    if custom:
+         os.symlink(f"{base}/custom/{custom}.py" , f"{base}/custom/__init__.py")
+
+    with patchit(base, patchfile):
+        run( generator )
+        try:
+            os.unlink(f"{base}/logs/declad.log")
+        except FileNotFoundError:
+            pass
+        run(f"cd {base} && ./restart.sh")
+
+        try:
+           res = watch_log(f"{base}/logs/declad.log", ext_flag)
+        except:
+           res = False
+
+        run(f"cd {base} && ./stop.sh")
+
+    # cleanup to not confuse later tests, and to make sure
+    # dropbox/quarantine are empty
+    if not cleanup_dirs([f"{base}/dropbox", f"{base}/quarantine"]):
+        os.system(f"rm -rf {base}/dropbox {base}/quarantine")
+        res = False
+    os.mkdir(f"{base}/dropbox")
+    os.mkdir(f"{base}/quarantine")
+
+    assert( res != fail )
+
+base = "/home/hypotpro/declad_848"
+
+
+def test_no_custom_init_py_fails():
+    generic_case(base, None, None, "make_test_ext_data.sh", 5, True, True)
+    with open(f"{base}/logs/nohup.out") as f:
+        data = f.read()
+    assert(data.find("did you forget to symlink") > 0)
+
+def test_hypot_extractor():
+    generic_case(base, "hypot", None, "make_test_ext_data.sh", 5, True, False)
+

--- a/tests/declad_test.py
+++ b/tests/declad_test.py
@@ -19,10 +19,10 @@ class patchit:
 re_nfiles  = re.compile(r"scanner returned [1-9][0-9]* file descriptors")
 re_extract = re.compile(r"Running:.*demo_meta_extractor.sh")
 re_cmd     = re.compile(r"runCommand: ")
-re_after   = re.compile(r"known files before and after: [1-9]")
 re_trace   = re.compile(r"Traceback")
 re_xfer_s  = re.compile(r"transferring data")
 re_xfer_e  = re.compile(r"data transfer complete")
+re_after   = re.compile(r"known files before and after: [1-9]")
 
 def readline_wait(fd):
     # do tail -f style read...
@@ -134,6 +134,7 @@ def generic_case( base, custom, patchfile, generator, nfiles, ext_flag, fail = F
 # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 # actual tests, mostly written with generic_case, above
 base = "/home/hypotpro/declad_848"
+prefix = os.path.dirname(os.path.dirname(__file__))
 
 def test_no_custom_init_py_fails():
     # this is the test for issue #12
@@ -149,6 +150,14 @@ def test_hypot_extractor():
 def test_hypot_json_meta():
     # test using new metadata issue #10
     generic_case(base, "hypot", None, "make_test_newdata.sh", 5, False)
+
+def test_dune_json_meta():
+    # test using new metadata issue #10
+    generic_case(base, "dune", None, "make_test_newdata.sh", 5, False)
+
+def test_mu2e_json_meta():
+    # test using new metadata issue #10
+    generic_case(base, "mu2e", None, "make_test_newdata.sh", 5, False)
 
 def test_hypot_json_ups():
     # basic test using old ups-style metadata


### PR DESCRIPTION
While you can template the copy command for transfers, you were constrained to 
root: URL's both in the construction of the ${dest} value for copy command templates
and in how the destination was checked for file sizes. 

This pull request lets you pick a different protocol (specifically "https" ) in the config
and uses gfal-stat to collect info. 

Also, we did not have a testing framework that allows various scenarios to be tested.
We now have one that can be run on a suitably setup instance.