### PR TITLE
test case with patch for config, adding make_test scripts

### DIFF
--- a/tests/patches/config_hashdir.patch
+++ b/tests/patches/config_hashdir.patch
@@ -1,0 +1,11 @@
+--- a/declad_config.yaml	2024-10-28 16:55:21.668400939 -0500
++++ b/declad_config.yaml	2024-10-28 16:55:02.507526464 -0500
+@@ -71,7 +71,7 @@
+   replace_location:                                  # replace Dropbox location with this in path for local scanner
+   path: /home/hypotpro/declad_848/dropbox
+   location: /home/hypotpro/declad_848/dropbox
+-  ls_command_template: "ls -ln $location"               # with $server and $location 
++  ls_command_template: "cd $location && ls -ln ??/*"               # with $server and $location 
+   parse_re:              "^(?P<type>[a-z-])\\S+\\s+\\d+\\s+\\d+\\s+\\d+\\s+(?P<size>\\d+)\\s+\\S.{11}\\s(?P<path>\\S+)$"                                          
+                                                      # regexp for "ls" / "xrdfs" ls  output                                          
+   filename_patterns:                                # filename pattern(s) to watch for

--- a/tests/scripts/demo_meta_extractor.sh
+++ b/tests/scripts/demo_meta_extractor.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+#
+# make dummy datafiles to test declad.
+# -- this time with *new* metadata...
+#
+
+ds=$(date +%s)
+dropbox=/home/hypotpro/declad_848/dropbox
+
+for fname in $*
+do
+    if [ -r ${fname}.json ] 
+    then
+	:
+    else
+	echo "$(date -u) demo-metadata-extractor: generating ${fname}.json"
+
+        # adding just the minmium metadata to make our declad_config happy
+
+	fsize=$(stat --format '%s' ${dropbox}/${fname})
+	chksum=$(xrdadler32 ${dropbox}/${fname} | sed -e 's/ .*//')
+	cat > ${dropbox}/${fname}.json <<EOF
+{
+"name": "$fname",
+"namespace": "hypotpro",
+"size": $fsize,
+"checksums": {"adler32": "$chksum"},
+"metadata": {
+    "dh.type": "other",
+    "rs.runs": [1000001],
+    "fn.tier": "etc",
+    "fn.format": "txt",
+    "fn.owner": "hypotraw",
+    "fn.description": "declad_test3",
+    "fn.configuration": "c20240226"
+    }
+}
+EOF
+
+    fi
+done

--- a/tests/scripts/make_test_data.sh
+++ b/tests/scripts/make_test_data.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+#
+# make dummy datafiles to test declad.
+#
+
+ds=$(date +%s)
+
+for i in 1 2 3 4 5
+do
+
+
+fname="etc_txt_hypotpro_declad_test_c20240219_$ds$i.txt"
+dropbox=/home/hypotpro/declad_848/dropbox
+
+cat > ${dropbox}/${fname} <<EOF
+test file $fname
+EOF
+
+fsize=$(stat --format '%s' ${dropbox}/${fname})
+chksum=$(xrdadler32 ${dropbox}/${fname} | sed -e 's/ .*//')
+
+# adding just the minmium metadat to make our declad_config happy
+cat > ${dropbox}/${fname}.json <<EOF
+{
+"file_name": "$fname",
+"file_size": $fsize,
+"checksum": ["adler32:$chksum"],
+"file_format": "txt",
+"file_type": "other",
+"runs": [ [1,1,"test"]],
+"data_tier": "etc",
+"dh.owner": "hypotpro",
+"dh.description": "declad_test",
+"dh.configuration": "c20240226"
+}
+EOF
+
+done

--- a/tests/scripts/make_test_ext_data.sh
+++ b/tests/scripts/make_test_ext_data.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# make dummy datafiles to test declad for use with demo_metadata_extractor
+# -- this time with *new* metadata...
+#
+
+ds=$(date +%s)
+
+for i in 1 2 3 4 5
+do
+
+
+fname="hypotpro_declad_test_${ds}_${i}.txt"
+dropbox=/home/hypotpro/declad_848/dropbox
+
+cat > ${dropbox}/${fname} <<EOF
+test file $fname
+EOF
+
+done

--- a/tests/scripts/make_test_hash_newdata.sh
+++ b/tests/scripts/make_test_hash_newdata.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+#
+# make dummy datafiles to test declad.
+# -- this time with *new* metadata...
+#
+
+ds=$(date +%s)
+
+for i in 1 2 3 4 5
+do
+
+
+fname="$i$i/hypotpro_declad_test_${ds}_${i}.txt"
+dropbox=/home/hypotpro/declad_848/dropbox
+
+mkdir ${dropbox}/$i$i
+
+cat > ${dropbox}/${fname} <<EOF
+test file $fname
+EOF
+
+fsize=$(stat --format '%s' ${dropbox}/${fname})
+chksum=$(xrdadler32 ${dropbox}/${fname} | sed -e 's/ .*//')
+
+# adding just the minmium metadat to make our declad_config happy
+cat > ${dropbox}/${fname}.json <<EOF
+{
+"name": "$fname",
+"namespace": "hypotpro",
+"size": $fsize,
+"checksums": {"adler32": "$chksum"},
+"metadata": {
+    "dh.type": "other",
+    "rs.runs": [1000001],
+    "fn.tier": "etc",
+    "fn.format": "txt",
+    "fn.owner": "hypotraw",
+    "fn.description": "declad_test3",
+    "fn.configuration": "c20240226",
+    "core.runs":[1000001], 
+    "core.run_type": "test",
+    "core.file_type": "test"
+    }
+}
+EOF
+
+done

--- a/tests/scripts/make_test_newdata.sh
+++ b/tests/scripts/make_test_newdata.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+#
+# make dummy datafiles to test declad.
+# -- this time with *new* metadata...
+#
+
+ds=$(date +%s)
+
+for i in 1 2 3 4 5
+do
+
+
+fname="hypotpro_declad_test_${ds}_${i}.txt"
+dropbox=/home/hypotpro/declad_848/dropbox
+
+cat > ${dropbox}/${fname} <<EOF
+test file $fname
+EOF
+
+fsize=$(stat --format '%s' ${dropbox}/${fname})
+chksum=$(xrdadler32 ${dropbox}/${fname} | sed -e 's/ .*//')
+
+# adding just the minmium metadat to make our declad_config happy
+cat > ${dropbox}/${fname}.json <<EOF
+{
+"name": "$fname",
+"namespace": "hypotpro",
+"size": $fsize,
+"checksums": {"adler32": "$chksum"},
+"metadata": {
+    "dh.type": "other",
+    "rs.runs": [1000001],
+    "fn.tier": "etc",
+    "fn.format": "txt",
+    "fn.owner": "hypotraw",
+    "fn.description": "declad_test3",
+    "fn.configuration": "c20240226",
+    "core.runs":[1000001], 
+    "core.run_type": "test",
+    "core.file_type": "test"
+    }
+}
+EOF
+
+done


### PR DESCRIPTION
Test case for setup @rlcee had mentioned: using hashed subdirectories in dropbox to reduce total files per directory. 
The test doesn't actually use a hash, i puts the first file in directory 11, the second in 22 , etc. but the declad
config is the same, using "`cd $location && ls ??/*`" as the `ls_command`. 

This also fixes using patchfiles, on the config in the test harness, which wasn't actually tested before.