### PR TITLE
Fadvise revisited

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -559,7 +559,7 @@ class MoverTask(Task, Logged):
         if self.Config["scanner"].get("type") == "local":
             self.log(f"calling fadvise w/ dontneed for {src_data_path}")
             with open(src_data_path) as pf:
-                os.python_fadvise(src_data_path.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+                os.posix_fadvise(src_data_path.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
     @synchronized
     def timestamp(self, event, info=None):
         self.EventDict[event] = self.LastUpdate = t =  time.time()

--- a/declad/mover.py
+++ b/declad/mover.py
@@ -559,7 +559,7 @@ class MoverTask(Task, Logged):
         if self.Config["scanner"].get("type") == "local":
             self.log(f"calling fadvise w/ dontneed for {src_data_path}")
             with open(src_data_path) as pf:
-                os.posix_fadvise(src_data_path.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+                os.posix_fadvise(pf.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
     @synchronized
     def timestamp(self, event, info=None):
         self.EventDict[event] = self.LastUpdate = t =  time.time()

--- a/tests/declad_test.py
+++ b/tests/declad_test.py
@@ -173,3 +173,4 @@ def test_hypot_json_ups():
 
 def test_hypot_json_hash_meta():
     generic_case(base, "hypot", "config_hashdir.patch", "make_test_hash_newdata.sh", 5, False)
+


### PR DESCRIPTION
Directly calling os.posix_fadvise() so we don't need the python_fadvise package (which was apparently causing grief on Alma8?)   Also moved it to a `donewith(file)` method to not repeat ourselves, and in case we find other bookkeeping
we should do with files we're finished with later on. 