### PR TITLE
add try/except around fadvise bits

### DIFF
--- a/declad/mover.py
+++ b/declad/mover.py
@@ -558,8 +558,13 @@ class MoverTask(Task, Logged):
 
         if self.Config["scanner"].get("type") == "local":
             self.log(f"calling fadvise w/ dontneed for {src_data_path}")
-            with open(src_data_path) as pf:
-                os.posix_fadvise(pf.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+            try:
+                with open(src_data_path) as pf:
+                    os.posix_fadvise(pf.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+            except OSError as e:
+                self.log(f"Error {str(e)} from open/fadvise on {src_data_path} ignored.")
+                pass
+
     @synchronized
     def timestamp(self, event, info=None):
         self.EventDict[event] = self.LastUpdate = t =  time.time()


### PR DESCRIPTION

This is a fix for the condition in #59; which the user in that issue resolved by changing the scanner type
in their configuration correctly; however the code shouldn't leave stack traces etc. for this kind of error. 
So we catch any exception and have a brief log message when trying to fadvise().